### PR TITLE
Fixes for NPM package page

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ data.where({
 Contributions are welcome. Please fork the github repository and make your changes there, then open a pull request.
 If you find any bugs or other issues, please use the github repository Issues. Check if your issue has already been posted before you add a new issue.
 
-The github repository is at https://github.com/muze/array-where-select
+The github repository is at https://github.com/muze-nl/array-where-select
 
 <a name="license"></a>
 ## License

--- a/package.json
+++ b/package.json
@@ -10,9 +10,18 @@
 		"select",
 		"where"
 	],
+	"homepage": "https://github.com/muze-nl/array-where-select",
+	"bugs": {
+		"url": "https://github.com/muze-nl/array-where-select/issues"
+	},
+	"license": "MIT",
 	"main": "./src/whereselect.mjs",
 	"scripts": {
 		"test": "tap test/*.mjs"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/muze-nl/array-where-select.git"
 	},
 	"devDependencies": {
 		"tap": "~16.3.7"


### PR DESCRIPTION
This MR adds some metadata to the `package.json` so that the package page on NPM contains more info and links.
The items are added in the order that the keys are listed in https://docs.npmjs.com/cli/v6/configuring-npm/package-json

It also fixes a broken link in `README.md`.